### PR TITLE
Add ability to ping run/complete for jobs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -129,3 +129,6 @@ default['java']['install_flavor'] = 'oracle'
 default['java']['jdk_version'] = '7'
 default['java']['oracle']['accept_oracle_download_terms'] = true
 default['java']['oracle']['jce']['enabled'] = true
+
+default['et_cassandra']['cronitor']['backups']['enabled'] = false
+default['et_cassandra']['cronitor']['repairs']['enabled'] = false

--- a/recipes/repair_jobs.rb
+++ b/recipes/repair_jobs.rb
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2014 EverTrue, Inc., All Rights Reserved.
 
-cookbook_file '/usr/local/bin/cassandra-repair' do
+template '/usr/local/bin/cassandra-repair' do
   mode 0755
 end
 

--- a/templates/default/cassandra-repair.erb
+++ b/templates/default/cassandra-repair.erb
@@ -4,6 +4,10 @@ set -e
 
 let timeout=7200
 
+<% if node['et_cassandra']['cronitor']['repairs']['enabled'] -%>
+/usr/local/bin/cronitor_repairs run
+<% end -%>
+
 keyspaces=$(/usr/bin/cqlsh -e 'describe keyspaces;' \
   | awk 'RS="  " {print $0}' \
   | grep -v '^$' \
@@ -21,3 +25,7 @@ for ks in $keyspaces; do
     echo "$msg" | mail -s "Keyspace repair taking too long" root
   fi
 done
+
+<% if node['et_cassandra']['cronitor']['repairs']['enabled'] -%>
+/usr/local/bin/cronitor_repairs complete
+<% end -%>

--- a/templates/default/snapshot-cassandra.erb
+++ b/templates/default/snapshot-cassandra.erb
@@ -2,6 +2,10 @@
 
 set -e
 
+<% if node['et_cassandra']['cronitor']['backups']['enabled'] -%>
+/usr/local/bin/cronitor_backups run
+<% end -%>
+
 source /etc/cassandra/snapshots.conf
 
 root_dir=`dirname "<%= node['et_cassandra']['config']['data_file_directories'].first %>"`
@@ -69,3 +73,7 @@ for data_dir in $data_dirs; do
 done
 
 cd "$old_pwd"
+
+<% if node['et_cassandra']['cronitor']['backups']['enabled'] -%>
+/usr/local/bin/cronitor_backups complete
+<% end -%>

--- a/templates/default/upload-incrementals.erb
+++ b/templates/default/upload-incrementals.erb
@@ -2,6 +2,10 @@
 
 set -e
 
+<% if node['et_cassandra']['cronitor']['backups']['enabled'] -%>
+/usr/local/bin/cronitor_backups run
+<% end -%>
+
 source /etc/cassandra/snapshots.conf
 
 root_dir=`dirname "<%= node['et_cassandra']['config']['data_file_directories'].first %>"`
@@ -57,3 +61,7 @@ for data_dir in $data_dirs; do
 done
 
 cd "$old_pwd"
+
+<% if node['et_cassandra']['cronitor']['backups']['enabled'] -%>
+/usr/local/bin/cronitor_backups complete
+<% end -%>


### PR DESCRIPTION
The repairs & backups jobs can now be monitored by adding a script in a [wrapper cookbook](https://github.com/evertrue/et_contacts_cassandra-cookbook), and setting the appropriate attribute to `true`.

Super janky, but it gets us to a place where we monitor more than we do
now (which is none at all).

Assistance requested, @eherot, on vetting just how janky this really is.