### PR TITLE
Fix apt

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,9 @@ version          '6.0.0'
 
 supports 'ubuntu', '= 14.04'
 
+chef_version '~> 12.10'
+
 depends 'java', '~> 1.29'
-depends 'apt',  '~> 2.6'
 depends 'storage', '~> 2.2'
 depends 'cron'
 depends 'python'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,11 +4,14 @@
 #
 # Copyright (c) 2014 EverTrue, Inc., All Rights Reserved.
 
-if Chef::VersionConstraint.new('< 12.0.0').include? Chef::VERSION
-  raise 'This recipe requires chef-client version 12.0.0 or higher'
+if Chef::VersionConstraint.new('< 12.10.0').include? Chef::VERSION
+  raise 'This recipe requires chef-client version 12.10.0 or higher'
 end
 
-include_recipe 'apt'
+apt_update 'et_cassandra' do
+  action :nothing
+end.run_action :periodic
+
 include_recipe 'java'
 include_recipe 'et_cassandra::install'
 include_recipe 'et_cassandra::repair_jobs'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -6,6 +6,7 @@
 
 apt_repository 'cassandra' do
   uri 'http://debian.datastax.com/community'
+  distribution nil
   components %w(stable main)
   key 'http://debian.datastax.com/debian/repo_key'
 end


### PR DESCRIPTION
@eherot this fixes things up so that the cookbook converges again with Chef > 12.10.

Definitely a breaking change.