### PR TITLE
Update test goodness

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -24,8 +24,6 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-    driver:
-      image_id: ami-b2bc80da
 
 suites:
   - name: cloud-default

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -15,6 +15,7 @@ driver:
     Type: test
 
 transport:
+  name: sftp
   username: ubuntu
   ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ addons:
     packages:
     - chefdk
 env:
+  matrix:
+  - KITCHEN_SUITE=cloud-default
+  - KITCHEN_SUITE=cloud-opscenter
   global:
   - KITCHEN_YAML=.kitchen.cloud.yml
   - secure: X2sTENP5OzTbAX0LYfYbYgyyg7QNLmh5gSLXpeo1YWIQy7WFbsyzqOBONSi6U7CrvXmn182C9z6yPX9EXgormp6vse6vWHmsrL+40/oL4MON4PAmbTYTSima+EBCxT0MYV6NMyDlZr+6bJkRTQ+3IbbGa66xbXEnLtKernFDyPA=
@@ -33,4 +36,4 @@ install:
 script:
 - rubocop
 - foodcritic .
-- kitchen test -d always -c
+- kitchen test ${KITCHEN_SUITE} -d always

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 - rubocop --version
 - foodcritic --version
 install:
-- chef gem install kitchen-ec2
+- chef gem install kitchen-ec2 kitchen-sync
 - berks
 script:
 - rubocop


### PR DESCRIPTION
* Use `kitchen-sync`
* Use Travis’ own parallel testing matrix
* Use the latest AMI automatically